### PR TITLE
🔨update: Init #30 NewsCrawler.py 구단명을 겁색하면 전날 뉴스로 올라온 구단뉴스의 제목과 link를 …

### DIFF
--- a/src/webdriver/crawling/NewsCrawler.py
+++ b/src/webdriver/crawling/NewsCrawler.py
@@ -13,11 +13,12 @@ from datetime import timedelta
 class NewsCrawler(MyWebDriver):
     def __init__(self, driver: webdriver.Chrome, url: str) -> None:
         super().__init__(driver, url)
+        
     
     @staticmethod
-    def of(url: str) -> object:
+    def of() -> object:
         driver = webdriver.Chrome()
-        url = "https://www.koreabaseball.com/MediaNews/News/BreakingNews/List.aspx"   
+        url = "https://www.koreabaseball.com/MediaNews/News/BreakingNews/List.aspx"
         return NewsCrawler(driver, url)
     
     def run(self):
@@ -31,6 +32,7 @@ class NewsCrawler(MyWebDriver):
         self.news_date_element = self._driver.find_elements(By.CLASS_NAME,'date')       # 발행날짜
         self.news_title_element = self._driver.find_elements(By.CSS_SELECTOR,'.txt strong') # 제목
         self.news_link_element = self._driver.find_elements(By.CSS_SELECTOR,'.txt strong a')    # 뉴스 링크
+        
         return self.content_text()
          
 
@@ -45,17 +47,16 @@ class NewsCrawler(MyWebDriver):
     def content_text(self) -> list[object]:
         self.news_title = []
         self.news_title_link = []
-         
-        if self.day() == self.news_date_element[0].text:
-            for i in range(0,len(self.news_date_element)):
-                if self.day() == self.news_date_element[i].text:
+        
+        team_name = input("구단을 입력하세요")
+        
+        for i in range(0,len(self.news_date_element)):
+            if self.day() == self.news_date_element[i].text:
+                if team_name in self.news_title_element[i].text:
                     self.news_title.append(self.news_title_element[i].text)
                     self.news_title_link.append(self.news_link_element[i].get_attribute('href'))
-                    
-                elif self.day() != self.news_date_element[i].text:
-                    break
-                
-                else:
-                    self.news_title = '전날 경기가 없었습니다'
-                    break
+       
         return self.news_title, self.news_title_link
+    
+        
+    


### PR DESCRIPTION
…전달한다

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
구단명 검색하면 제목과 링크를 던져준다

### 이슈 사항


### To reviewer

